### PR TITLE
Service Calendar + Turbo Like button

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -13,23 +13,37 @@ class DashboardsController < ApplicationController
     end
 
     @announcements = Announcement.all
+    @user_id = User.find_by(email: current_admin.email).id
   end
 
   # Creates the 'like' in the UserAnnouncemnent table if it doesn't exist.
   # Otherwise, will perform a 'un-like' to remove the like from the announcment and UA table.
   def like
-    user_announcement = UserAnnouncement.find_by(like_params)
+    uid = like_params[:user_id]
+    aid = like_params[:announcement_id]
+    user_announcement = UserAnnouncement.find_by(user_id: uid, announcement_id: aid)
     if user_announcement.nil?
-      UserAnnouncement.create(like_params)
+      UserAnnouncement.create(user_id: uid, announcement_id: aid)
       redirect_to action: 'show'
     else
       user_announcement.destroy
       redirect_to action: 'show'
     end
+
+    # update_like
+
+  end
+  
+  def like_params
+    params.permit(:user_id, :announcement_id, :like, :not_liked)
   end
 
-  def like_params
-    params.permit(:user_id, :announcement_id)
+  # FIXEME
+  def update_like
+    render turbo_stream:
+      turbo_stream.replace("like",
+        partial: "likes",
+        locals: like_params) 
   end
 
   # FOR TESTING! REMOVE

--- a/app/views/announcements/calendar.html.erb
+++ b/app/views/announcements/calendar.html.erb
@@ -2,6 +2,6 @@
   <%# <h1 class="text-3xl font-bold" style="text-align:center;">Calendar</h1> %>
 
   <div class="grid h-screen place-items-center">
-  <iframe src="https://calendar.google.com/calendar/embed?src=chai.justin%40tamu.edu&ctz=America%2FChicago" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-  </div>
+<%# <iframe src="https://calendar.google.com/calendar/embed?src=saddleandsirlointamu%40gmail.com&ctz=America%2FChicago" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>  </div> %>
+<iframe src="https://calendar.google.com/calendar/embed?src=c_1b2ba3a0c5d0ac6eb82d42ca9e7763c8bcb8755d05c39efe5f875fe3d7dabe25%40group.calendar.google.com&ctz=America%2FChicago" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 </div>

--- a/app/views/dashboards/_likes.html.erb
+++ b/app/views/dashboards/_likes.html.erb
@@ -1,0 +1,28 @@
+<%# Like count IF NOT LIKED%>
+<% if not_liked %>
+    <%# Renders like count appropriate distance if 3 digits. Prevents overlapping %>
+    <% if like.to_i / 100 < 1%>
+        <div class="absolute left-10 text-right"><%= like %></div>
+    <%else%>
+        <div class="absolute left-5 text-right"><%= like%></div>
+    <%end%>
+<%else%>
+<%# Like count IF LIKED%>
+    <% if like.to_i / 100 < 1%>
+        <div class="absolute left-10 text-right text-rose-400"><%= like %></div>
+    <%else%>
+        <div class="absolute left-5 text-right text-rose-400"><%= like %></div>
+    <%end%>
+<%end%>
+
+<div class="absolute left-14">
+    <%# Like Button routing %>
+    <% if not_liked %>
+        <a href= "<%= like_path(:user_id => user_id, :announcement_id => announcement_id, :like => like, :not_liked => not_liked) %>" class="absolute w-6 h-6 rounded-full hover:bg-rose-400 hover:opacity-50 duration-300 cursor-pointer"></a>
+    <%else%>
+        <a href= "<%= like_path(:user_id => user_id, :announcement_id => announcement_id, :like => like, :not_liked => not_liked) %>" class="absolute w-6 h-6 rounded-full bg-rose-400 opacity-50 cursor-pointer"></a>
+    <%end%>
+
+    <%# Heart icon %>
+    <span class="pt-[3px] pr-[3px] material-icons" style="font-size:18px">favorite_border</span> 
+</div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -11,8 +11,8 @@
     <% @announcements.each do |ann|%>
         <%# Vars for like button interaction %>
         <% like = UserAnnouncement.where(announcement_id: ann.id).length %>
-        <% user_id = User.find_by(email: current_admin.email).id %>
-        <% not_liked = UserAnnouncement.where(announcement_id: ann.id, user_id: user_id).empty?%>
+        <% not_liked = UserAnnouncement.where(announcement_id: ann.id, user_id: @user_id).empty?%>
+        <% ann_id = ann.id %>
         <br>
 
     <%# Individual Announcement! %>
@@ -26,33 +26,11 @@
     </div>
     <%end%>
         <div class="relative mb-4 mt-1">
-            <%# Like count IF NOT LIKED%>
-            <% if not_liked %>
-                <%# Renders like count appropriate distance if 3 digits. Prevents overlapping %>
-                <% if like / 100 < 1%>
-                    <div class="absolute left-10 text-right"><%= like %></div>
-                <%else%>
-                    <div class="absolute left-5 text-right"><%= like%></div>
-                <%end%>
-            <%else%>
-            <%# Like count IF LIKED%>
-                <% if like / 100 < 1%>
-                    <div class="absolute left-10 text-right text-rose-400"><%= like %></div>
-                <%else%>
-                    <div class="absolute left-5 text-right text-rose-400"><%= like %></div>
-                <%end%>
-            <%end%>
-
-            <div class="absolute left-14">
-                <%# Like Button routing %>
-                <% if not_liked %>
-                    <a href= "<%= like_path(:user_id => user_id, :announcement_id => ann.id) %>" class="absolute w-6 h-6 rounded-full hover:bg-rose-400 hover:opacity-50 duration-300 cursor-pointer"></a>
-                <%else%>
-                    <a href= "<%= like_path(:user_id => user_id, :announcement_id => ann.id) %>" class="absolute w-6 h-6 rounded-full bg-rose-400 opacity-50 cursor-pointer"></a>
-                <%end%>
-                <%# Heart icon %>
-                <span class="pt-[3px] pr-[3px] material-icons" style="font-size:18px">favorite_border</span> 
-            </div>
+        <%# TURBO START %>
+        <%= turbo_frame_tag "like" do%>
+            <%= render(partial: "likes", locals:  {like: like, not_liked: not_liked, user_id: @user_id, announcement_id: ann_id} ) %>
+        <%# TURBO END %>
+        <%end%>
         </div>
     <%end%>
 

--- a/app/views/events/previous.html.erb
+++ b/app/views/events/previous.html.erb
@@ -24,7 +24,6 @@
   </div>
 </div>
 
-
 <% @events.each do |event|%>
   <br>
   <%# checks event date and compares it to current date. Only renderes the events that are in the past %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
   # OATH
   ENV['GOOGLE_OAUTH_CLIENT_ID'] = '881177367415-rdd0lakl4cu39mc42t5vqclabnkft5ne.apps.googleusercontent.com'
   ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
+
+  ENV['GOOGLE_APPLICATION_CREDENTIALS']='config/environments/service_account_cred.json'
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/service_account_cred.json
+++ b/config/environments/service_account_cred.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "csce431-377416",
+  "private_key_id": "8e5fff279e91ac1fa3ed99f2b0650624c6c280c7",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCKnQd8iN1PxCdP\nAFNaMlootrAIAb/JcBbuUJUNe/tEAtaOeLoPZc6C9F4v+oXkydMjtSidlky+ch+p\nhYj7Izhi1HBaqd9z0c8v/1MrG/Sum7yRKKpjyPQHmmFQo81Vlm2G02EBxGoPAtWd\nciEsWXLkBrlYVevVRHoiBdv3oE2CX/vhF8xMJ88lNJRWTk9hE4t1kUc1+dtBNnMN\nuqqmgmHJ2txLEhg962E5bedpHBPffqZpEguG0aLHoM98G6eoE3u5zxWcHwEt9o8y\n06e/3ex33LtvGTdERNmhyrh79bWwAQPVrGHsu5RM7AelQmVssMe8zA9QPJNbqCWv\nBTWLm5DxAgMBAAECggEABzpoDQjwDXxLlnWMYyw0AmKAbHJ251C2iWffVewsrp+9\nQ4GtJidnbPHERZk5STRzE64bN5iCWP4Hg6YIfhwYkSLF1xx7oAUFWlnkot9a044g\nd6tYs0pj20+kGnnoN7nX7UtxiA+PfkfmDsdITpE9igGFwcL9QMpI2iRXE6Mi15UJ\nHn8C5afSVNe/kGL6gLRIXWBUs0EgxJS8XX8NBXsudXqHG77EzMU96ev5K96S3hSA\nK5F0ErH7OQ2lC8NVtqtzS1BDBl+p3RzyXBJ5rw7x+6PniTUSf8W1iHteieRT+/dP\nKQ2xFLOs6/pW149W8fw+3/G4sTl47sv0+DG4DrErAQKBgQC8eJcdfOX+hY7gPzCj\nA1NS7+PKP+3+3gEx1Z1IOSFmuwmTiYwebpG96Bw52+3IZgHfYDcV1odHzQz8wtaI\nsjWkbYLHyiF++vjef6a3GgxRD1C12fq/EoMASEGWOXpwPEFKk0tkhbOtQPYxWCEZ\nKDQESSHykTpsx5saBZxcADPSoQKBgQC8R0Vc/zg6RROtHRr8IVDTm8LU0o1zdmJk\nJYsy+GTXzSlB/mVP8617+niWASiL6/65nuzjxjwN0gY9EDXXYovuYzdES/b5SHdr\nLu/VOopA6ZXb7MqYCsoHVEykxK6+JS9wuHu43n2mRts4efyXo36b9fXybUVU9sno\nVL+v+hpsUQKBgBj57iTFQYF6V5XWKe7gaPFrwwcxc6u75fKhuWcx0wBXNwyrRLtf\nsca19M+iGp/dDNB6YrJtLJ5SSS9R7rZMz5kLvjIV0lyOi96IkiJfvFQdsHd4/KbH\noD6wVKjA0z3+bjSg0nPu2AHUwwuE/1XjIwmSW4JWxqRVy3MmXTM//54hAoGAHFf2\nXzuksVD411TMXSx+yHxoZjWUSc+GnGDyhafTNpGSJncvtUuP0FwyjxJ5kibi3/rG\n2rtbCxGVEtg/4r7ZJfgVt9hfw8NfBum3/Tek3ITNpKAPF7h4FYZhS2S4kbNzYtrC\n9V+5NrDwC56BoipgwwXSEr7Ucyf72Vf4y3sxQyECgYAWLL5rpfSodzpAP11/WKu5\nVtL35thVsqHQHllJNjPNXNBLUREO/Fq0kEr+Fsobj/gqTo54UlhSLXO3kFHGrsqA\na11EghtUKP6r6wi4OYRPT1FLi0CQly3nZ1oA8L59++rm9EZgH4Es4pLLU2n2d23y\n6Z7bd4EfCSZ78uWUjNhfkQ==\n-----END PRIVATE KEY-----\n",
+  "client_email": "saddle-sirloin@csce431-377416.iam.gserviceaccount.com",
+  "client_id": "104385318423465182414",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/saddle-sirloin%40csce431-377416.iam.gserviceaccount.com"
+}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,80 +10,80 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_326_003_123) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_26_003123) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'admins', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'full_name'
-    t.string 'uid'
-    t.string 'avatar_url'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'name'
-    t.string 'access_token'
-    t.datetime 'expires_at'
-    t.string 'refresh_token'
-    t.index ['email'], name: 'index_admins_on_email', unique: true
+  create_table "admins", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "full_name"
+    t.string "uid"
+    t.string "avatar_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.string "access_token"
+    t.datetime "expires_at"
+    t.string "refresh_token"
+    t.index ["email"], name: "index_admins_on_email", unique: true
   end
 
-  create_table 'announcements', force: :cascade do |t|
-    t.string 'title'
-    t.string 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "announcements", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'events', force: :cascade do |t|
-    t.string 'name'
-    t.date 'date'
-    t.integer 'event_type'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'description'
-    t.time 'start_time'
-    t.time 'end_time'
-    t.string 'google_event_id'
-    t.boolean 'isActive', default: true
+  create_table "events", force: :cascade do |t|
+    t.string "name"
+    t.date "date"
+    t.integer "event_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "description"
+    t.time "start_time"
+    t.time "end_time"
+    t.string "google_event_id"
+    t.boolean "isActive", default: true
   end
 
-  create_table 'user_announcements', force: :cascade do |t|
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.bigint 'user_id'
-    t.bigint 'announcement_id'
-    t.index ['announcement_id'], name: 'index_user_announcements_on_announcement_id'
-    t.index ['user_id'], name: 'index_user_announcements_on_user_id'
+  create_table "user_announcements", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.bigint "announcement_id"
+    t.index ["announcement_id"], name: "index_user_announcements_on_announcement_id"
+    t.index ["user_id"], name: "index_user_announcements_on_user_id"
   end
 
-  create_table 'user_events', force: :cascade do |t|
-    t.boolean 'attendance'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.bigint 'user_id'
-    t.bigint 'event_id'
-    t.index ['event_id'], name: 'index_user_events_on_event_id'
-    t.index ['user_id'], name: 'index_user_events_on_user_id'
+  create_table "user_events", force: :cascade do |t|
+    t.boolean "attendance"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.bigint "event_id"
+    t.index ["event_id"], name: "index_user_events_on_event_id"
+    t.index ["user_id"], name: "index_user_events_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.integer 'uin'
-    t.string 'first_name'
-    t.string 'last_name'
-    t.string 'email'
-    t.string 'phone'
-    t.string 'password'
-    t.boolean 'isActive', default: false
-    t.integer 'role'
-    t.integer 'classify'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'isRequesting', default: true
+  create_table "users", force: :cascade do |t|
+    t.integer "uin"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "phone"
+    t.string "password"
+    t.boolean "isActive", default: false
+    t.integer "role"
+    t.integer "classify"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "isRequesting", default: true
   end
 
-  add_foreign_key 'user_announcements', 'announcements'
-  add_foreign_key 'user_announcements', 'users'
-  add_foreign_key 'user_events', 'events'
-  add_foreign_key 'user_events', 'users'
+  add_foreign_key "user_announcements", "announcements"
+  add_foreign_key "user_announcements", "users"
+  add_foreign_key "user_events", "events"
+  add_foreign_key "user_events", "users"
 end


### PR DESCRIPTION
Refactored calendar to support a service account that is configured in our Google Cloud Platform. All credentials verified and current display calendar is my local tester 'Embed Example'. It should be very easily portable to S&S calendar. Additionally, beginning implementation of Turbo Links on the announcement like button. Still need to configure linking order, can sometimes turbo refresh before the database updates causing a 'nonresponsive' looking click.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
